### PR TITLE
Don't send a body on GET requests

### DIFF
--- a/pyavatax/base.py
+++ b/pyavatax/base.py
@@ -188,6 +188,7 @@ class BaseAPI(object):
         resp = None
         try:
             if http_method == 'GET':
+                kwargs.pop('data')
                 resp = requests.get(url, **kwargs)
             elif http_method == 'POST':
                 resp = requests.post(url, **kwargs)


### PR DESCRIPTION
Fix failing smoke tests by not sending a body on HTTP GET requests.