### PR TITLE
PROCAT-2302 - Allow CurrencyCode field to be set in Document class

### DIFF
--- a/pyavatax/base.py
+++ b/pyavatax/base.py
@@ -377,8 +377,11 @@ class Document(AvalaraBase):
     CANCEL_ADJUSTMENT_CANCELED = 'AdjustmentCanceled'
     CANCEL_CODES = (CANCEL_POST_FAILED, CANCEL_DOC_DELETED, CANCEL_DOC_VOIDED, CANCEL_ADJUSTMENT_CANCELED)
 
-
-    _fields = ['DocType', 'DocId', 'DocCode', 'DocDate', 'CompanyCode', 'CustomerCode', 'Discount', 'Commit', 'CustomerUsageType', 'PurchaseOrderNo', 'ExemptionNo', 'PaymentDate', 'ReferenceCode', 'PosLaneCode', 'Client', 'BusinessIdentificationNo']
+    _fields = ['DocType', 'DocId', 'DocCode', 'DocDate', 'CompanyCode',
+               'CustomerCode', 'Discount', 'Commit', 'CustomerUsageType',
+               'PurchaseOrderNo', 'ExemptionNo', 'PaymentDate',
+               'ReferenceCode', 'PosLaneCode', 'Client',
+               'BusinessIdentificationNo', 'CurrencyCode']
     _contains = ['Lines', 'Addresses']  # the automatic parsing in `def update` doesn't work here, but its never invoked here
     _has = ['DetailLevel', 'TaxOverride']
 

--- a/test_businessidentificationno.py
+++ b/test_businessidentificationno.py
@@ -1,6 +1,5 @@
-from unittest import TestCase, mock
+from unittest import TestCase
 
-from pyavatax.api import API
 from pyavatax.base import Document
 
 
@@ -43,4 +42,5 @@ class TestBusinessIdentificationNo(TestCase):
         dictionary = doc.todict()
 
         self.assertIn("BusinessIdentificationNo", dictionary.keys())
-        self.assertEqual(dictionary.get("BusinessIdentificationNo"), "GB999 999")
+        self.assertEqual(dictionary.get("BusinessIdentificationNo"),
+                         "GB999 999")

--- a/test_currencycode.py
+++ b/test_currencycode.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+from pyavatax.base import Document
+
+
+class TestCurrencyCode(TestCase):
+
+    def test_currency_code_is_set_in_document_object(self):
+        currency = 'gbp'
+        doc = Document(
+            DocType='SalesInvoice',
+            CustomerCode='123456789',
+            DocCode='12345',
+            CompanyCode='COMPANY_CODE',
+            CurrencyCode=currency
+        )
+
+        doc.add_from_address(
+            Line1='000 Main Street',
+            City='New York',
+            Region='NY',
+            Country='US',
+            PostalCode='10000'
+        )
+
+        doc.add_to_address(
+            Line1='001 Main Street',
+            Line2='',
+            City='New York',
+            Region='NY',
+            Country='US',
+            PostalCode='10000'
+        )
+
+        doc.add_line(
+            LineNo='1',
+            ItemCode='123456789',
+            Qty=1,
+            Amount=str(100)
+        )
+
+        dictionary = doc.todict()
+
+        self.assertIn("CurrencyCode", dictionary.keys())
+        self.assertEqual(dictionary.get("CurrencyCode"), currency)


### PR DESCRIPTION
Enable CurrencyCode in Document class. This allows BAPI to set the CurrencyCode when generating a new tax calculation.